### PR TITLE
Fix build under stack. Added opentelemetry extra-deps

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -15,5 +15,7 @@ extra-deps:
 - haddock-library-1.8.0
 - tasty-rerun-1.1.17
 - ghc-check-0.1.0.3
+- opentelemetry-0.3.2
+
 nix:
   packages: [zlib]

--- a/stack810.yaml
+++ b/stack810.yaml
@@ -8,6 +8,7 @@ extra-deps:
 - haskell-lsp-types-0.21.0.0
 - lsp-test-0.10.2.0
 - ghc-check-0.1.0.3
+- opentelemetry-0.3.2
 
 # for ghc-8.10
 - Cabal-3.2.0.0

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -6,6 +6,7 @@ extra-deps:
 - haskell-lsp-types-0.22.0.0
 - lsp-test-0.10.3.0
 - ghc-check-0.1.0.3
+- opentelemetry-0.3.2
 
 nix:
   packages: [zlib]


### PR DESCRIPTION
Added opentelemetry-0.3.2 dependency for all ghc versions other that 8.4. opentelemetry
requires Cabal>=2.4 which conflicts with lens which requires Cabal<2.3

stack84.yaml currently does not build.