### PR TITLE
Expose `getCompletionsLSP` to allow completions in hls

### DIFF
--- a/src/Development/IDE/Plugin/Completions.hs
+++ b/src/Development/IDE/Plugin/Completions.hs
@@ -2,7 +2,11 @@
 {-# LANGUAGE TypeFamilies #-}
 #include "ghc-api-version.h"
 
-module Development.IDE.Plugin.Completions(plugin) where
+module Development.IDE.Plugin.Completions
+    (
+      plugin
+    , getCompletionsLSP
+    ) where
 
 import Control.Applicative
 import Language.Haskell.LSP.Messages


### PR DESCRIPTION
The ghcide plugin for HLS requires this function to be exposed, so when this is eventually merged into the hls master, the PR at https://github.com/haskell/haskell-language-server/pull/107 should be ready to go.