### PR TITLE
Typecheck files when they are opened

### DIFF
--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -194,7 +194,7 @@ setFileModified state prop nfp = do
     VFSHandle{..} <- getIdeGlobalState state
     when (isJust setVirtualFileContents) $
         fail "setSomethingModified can't be called on this type of VFSHandle"
-    let da = mkDelayedAction "FileStoreTC" (TypeCheck, nfp) L.Info (void $ use GetHieFile nfp)
+    let da = mkDelayedAction "FileStoreTC" (TypeCheck, nfp) L.Info (void $ use GetDocMap nfp)
         parents = mkDelayedAction "ParentTC" ("Parents" :: String, nfp) L.Debug (typecheckParents nfp)
     shakeRunInternalKill state
       ([da] ++ [parents | prop])

--- a/src/Development/IDE/LSP/Notifications.hs
+++ b/src/Development/IDE/LSP/Notifications.hs
@@ -39,6 +39,7 @@ setHandlersNotifications = PartialHandlers $ \WithMessage{..} x -> return x
             updatePositionMapping ide (VersionedTextDocumentIdentifier _uri (Just _version)) (List [])
             whenUriFile _uri $ \file -> do
                 modifyFilesOfInterest ide (S.insert file)
+                setFileModified ide False file
                 logInfo (ideLogger ide) $ "Opened text document: " <> getUri _uri
 
     ,LSP.didChangeTextDocumentNotificationHandler = withNotification (LSP.didChangeTextDocumentNotificationHandler x) $


### PR DESCRIPTION
Since we don't typecheck of modifying files of interest, this seems like a good idea and makes the first request to the IDE not fail.

Also use `GetDocMap` on open instead of `GetHieFile` so that hover is instantly available.

